### PR TITLE
Remove coverage upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,8 @@ jobs:
       - name: Build solution
         run: dotnet build --no-restore
       - name: Test solution
-        run: dotnet test --no-restore --collect:"XPlat Code Coverage"
+        run: dotnet test --no-restore
       - name: Check code formatting
         run: dotnet format --no-restore --verify-no-changes
       - name: Check code style
         run: dotnet format --no-restore --verify-no-changes style
-      - name: Upload coverage report
-        uses: codacy/codacy-coverage-reporter-action@v1
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: tests/GuitarProToMidi_UnitTests/TestResults/*/coverage.cobertura.xml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ![Build status](https://github.com/rageagainsthepc/GuitarPro-to-Midi/actions/workflows/build.yml/badge.svg)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/cf3eccd35e954adb8489ad35d1bf5e9d)](https://www.codacy.com/gh/rageagainsthepc/GuitarPro-to-Midi/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=rageagainsthepc/GuitarPro-to-Midi&amp;utm_campaign=Badge_Grade)
-[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/cf3eccd35e954adb8489ad35d1bf5e9d)](https://www.codacy.com/gh/rageagainsthepc/GuitarPro-to-Midi/dashboard?utm_source=github.com&utm_medium=referral&utm_content=rageagainsthepc/GuitarPro-to-Midi&utm_campaign=Badge_Coverage)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/rageagainsthepc/GuitarPro-to-Midi)
 
 # GuitarPro-to-Midi


### PR DESCRIPTION
Remove coverage generation and upload. As of now the codacy coverage upload action does not offer a way to handle coverage uploads from forks. Since the project is mostly untested anyway there is little benefit to knowing the current coverage status.